### PR TITLE
fix: wrong firestore endpoint URL constructor

### DIFF
--- a/.changeset/famous-suns-end.md
+++ b/.changeset/famous-suns-end.md
@@ -1,0 +1,5 @@
+---
+'fireworkers': patch
+---
+
+fix: wrong firestore endpoint URL constructor

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,11 +11,9 @@ export const get_firestore_endpoint = (
   paths: string[] = [],
   suffix = ''
 ): URL => {
-  const path = paths.join('/') + suffix;
-  const endpoint = new URL(
-    path,
-    `${FIRESTORE_ENDPOINT}/v1/projects/${project_id}/databases/(default)/documents`
-  );
+  const allPaths = ['v1', 'projects', project_id, 'databases', '(default)', 'documents', ...paths];
+  const path = allPaths.join('/') + suffix;
 
+  const endpoint = new URL(path, FIRESTORE_ENDPOINT);
   return endpoint;
 };


### PR DESCRIPTION
Closes #16, the bug was introduced in #14 by mistake. 