### PR TITLE
Added `Firestore.set()`, fixed `Firestore.update()`

### DIFF
--- a/.changeset/sharp-guests-stare.md
+++ b/.changeset/sharp-guests-stare.md
@@ -1,0 +1,10 @@
+---
+'fireworkers': minor
+---
+
+**This release deliberately contains backwards-incompatible changes**. To avoid automatically picking up releases like this, you should either be pinning the exact version of `fireworkers` in your `package.json` file (recommended) or be using a version range syntax that only accepts patch upgrades such as `^0.2.0` or `~0.2.0`. See npm's documentation about [semver](https://docs.npmjs.com/cli/v6/using-npm/semver/) for more information.
+
+- feat: add new `Firestore.set()` method that matches the behavior of the SDK's [setDoc](https://firebase.google.com/docs/reference/js/firestore_.md#setdoc).
+- fix: update `Firestore.update()` to match the behavior of the SDK's [updateDoc](https://firebase.google.com/docs/reference/js/firestore_.md#updatedoc):
+  - Fields will be merged instead of overriding the entire document.
+  - Operations will fail if the document doesn't exist.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ const newTodo = await Firestore.create(db, 'todos', {
 
 ### update(db, ...document_path, fields)
 
-Updates or inserts a document.
+Updates fields in a document. The update will fail if applied to a document that does not exist.
+
+Implements the same functionality as Firestore's [updateDoc](https://firebase.google.com/docs/reference/js/firestore_.md#updatedoc).
 
 #### db
 
@@ -183,6 +185,48 @@ The fields to update.
 const updatedTodo = await Firestore.update(db, 'todos', 'aDyjLiTViX1G7HyF74Ax', {
   completed: false,
 });
+```
+
+---
+
+### set(db, ...document_path, fields, options?)
+
+Writes to a document. If the document does not yet exist, it will be created. If you provide `merge`, the provided data can be merged into an existing document.
+
+Implements the same functionality as Firestore's [setDoc](https://firebase.google.com/docs/reference/js/firestore_.md#setdoc_2).
+
+#### db
+
+Type: `DB`
+
+The DB instance.
+
+#### document_path
+
+Type: `string`
+
+The document path, defined like in [get](#document_path).
+
+#### fields
+
+Type: `Record<string, any>`
+
+The fields to update.
+
+#### (Optional) options.merge
+
+Type: `boolean`
+
+If set to `true`, the provided data will be merged into an existing document instead of overwriting.
+
+```typescript
+const updatedTodo = await Firestore.update(
+  db,
+  'todos',
+  'aDyjLiTViX1G7HyF74Ax',
+  { completed: false },
+  { merge: true }
+);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Type: `boolean`
 If set to `true`, the provided data will be merged into an existing document instead of overwriting.
 
 ```typescript
-const updatedTodo = await Firestore.update(
+const updatedTodo = await Firestore.set(
   db,
   'todos',
   'aDyjLiTViX1G7HyF74Ax',


### PR DESCRIPTION
**This release deliberately contains backwards-incompatible changes**. To avoid automatically picking up releases like this, you should either be pinning the exact version of `fireworkers` in your `package.json` file (recommended) or be using a version range syntax that only accepts patch upgrades such as `^0.2.0` or `~0.2.0`. See npm's documentation about [semver](https://docs.npmjs.com/cli/v6/using-npm/semver/) for more information.

- feat: add new `Firestore.set()` method that matches the behavior of the SDK's [setDoc](https://firebase.google.com/docs/reference/js/firestore_.md#setdoc).
- fix: update `Firestore.update()` to match the behavior of the SDK's [updateDoc](https://firebase.google.com/docs/reference/js/firestore_.md#updatedoc):
  - Fields will be merged instead of overriding the entire document.
  - Operations will fail if the document doesn't exist.

Closes #19 