### PR TITLE
Switch from `jose` to `cloudflare-worker-jwt`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "jose": "^4.11.2",
+    "@tsndr/cloudflare-worker-jwt": "^2.5.2",
     "superstruct": "^1.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  jose:
-    specifier: ^4.11.2
-    version: 4.11.2
+  '@tsndr/cloudflare-worker-jwt':
+    specifier: ^2.5.2
+    version: 2.5.3
   superstruct:
     specifier: ^1.0.3
     version: 1.0.3
@@ -570,6 +570,10 @@ packages:
       '@types/node': 18.11.18
       playwright-core: 1.29.2
     dev: true
+
+  /@tsndr/cloudflare-worker-jwt@2.5.3:
+    resolution: {integrity: sha512-zbdvjRG86y/ObiBgTJrzBC39t2FcaeGwB6AV7VO4LvHKJNyZvLYRbKT68eaoJhnJldyHhs7yZ69neRVdUd9knA==}
+    dev: false
 
   /@types/is-ci@3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
@@ -1822,10 +1826,6 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
-
-  /jose@4.11.2:
-    resolution: {integrity: sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==}
-    dev: false
 
   /js-sdsl@4.2.0:
     resolution: {integrity: sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==}


### PR DESCRIPTION
I've had many issues with `fireworkers` with Cloudflare Pages (in a SvelteKit project).

At build time (on deployment), the build fails due to lack of `CryptoKey`, which is extremely weird.

![image](https://github.com/finsweet/fireworkers/assets/35589610/841df93b-98a5-49a7-898c-8d080cf0463d)


However, I found a workaround inspired by https://github.com/panva/jose/discussions/411 (not included in this PR), by polyfilling `CryptoKey` from `@peculiar/webcrypto` before calling `Fireworkers.init(...)`.

```typescript
import { CryptoKey } from "@peculiar/webcrypto";
globalThis.CryptoKey = CryptoKey;
```

However, this fix only works when using `@tsndr/cloudflare-worker-jwt`, while `jose` complains about `CryptoKey` not being the same as the one it expects.

I'm currently using this version in a real app and it works flawlessly.

While `jose` should normally work just fine on any environment, `cloudflare-worker-jwt` is a pretty solid replacement, especially that `fireworkers` is targeting Cloudflare Workers specifically.

Maybe I'm missing something here, so it's okay if you refuse this change!